### PR TITLE
Rootconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Here's an example usage of slog.
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -21,26 +20,22 @@ import (
 
 func main() {
 	// Create the logger.
-	c := slog.Config{
+	c := slog.RootConfig{
 		Writer: os.Stderr,
-		Name:   "SLOG:",
-		Prefix: "slog",
-		SystemTags: slog.T{
-			"service": "slog",
-			"unit":    "slog-us-1",
-		},
-		AppTags: slog.T{"revno": "678"},
-	}
+		Config: slog.Config{
+			Name:   "SLOG:",
+			Prefix: "slog",
+			SystemTags: slog.T{
+				"service": "slog",
+				"unit":    "slog-us-1",
+			},
+			AppTags: slog.T{"revno": "678"},
+		}}
 	logger := slog.New(c)
 
 	// Derive a Logger from an existing one.
 	l := logger.New(slog.Config{Name: "SUBSYSTEM:"})
 	l.Info("Derived Logger", nil)
-
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
 
 	// Turn off flags, slog composes log messages in logfmt
 	log.SetFlags(0)

--- a/slog.go
+++ b/slog.go
@@ -20,16 +20,20 @@ type Logger struct {
 	prefix     string
 }
 
+type RootConfig struct {
+	Writer io.Writer // optional
+	Config           // optional
+}
+
 type Config struct {
-	Writer     io.Writer // optional
-	Name       string    // optional
-	Prefix     string    // optional
+	Name       string // optional
+	Prefix     string // optional
 	SystemTags T
 	AppTags    T
 }
 
 // Create a new logger based on the passed in config.
-func New(c Config) *Logger {
+func New(c RootConfig) *Logger {
 	l := new(Logger)
 
 	if c.Writer == nil {

--- a/slog_test.go
+++ b/slog_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-var config Config = Config{Prefix: "SAS:", Name: "sas"}
+var config RootConfig = RootConfig{Config: Config{Prefix: "SAS:", Name: "sas"}}
 
 // Test that the standard logger has our prefix and a default level of 'INFO'
 func TestLoggerStdLogOutput(t *testing.T) {
@@ -141,9 +141,9 @@ func TestLoggerFromLogger(t *testing.T) {
 	c.Writer = buf
 	l := New(c)
 
-	c = Config{SystemTags: T{"extra": "extra"}}
+	c = RootConfig{Config: Config{SystemTags: T{"extra": "extra"}}}
 
-	nl := l.New(c)
+	nl := l.New(c.Config)
 	nl.Info("testing", nil)
 
 	// Fields that should be inherited


### PR DESCRIPTION
Add RootConfig to contain the Writer which is only needed by slog.New() not Logger.New().
