### PR TITLE
Add Logger.Fatal() similar to log.Fatal().

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -145,6 +145,11 @@ func (l *Logger) Error(msg string, tags T) {
 	l.log(msg, "ERROR", tags)
 }
 
+func (l *Logger) Fatal(msg string, tags T) {
+	l.log(msg, "ERROR", tags)
+	os.Exit(1)
+}
+
 func (l *Logger) Write(bytes []byte) (int, error) {
 	// remove trailing whitespace
 	l.Info(strings.TrimSpace(string(bytes)), nil)


### PR DESCRIPTION
This seems useful and should make changing loggers have smaller diffs.
